### PR TITLE
Allow Cabal 2.2 (from the GHC 8.4 era) and adjust allowed warnings

### DIFF
--- a/ilist.cabal
+++ b/ilist.cabal
@@ -1,4 +1,4 @@
-cabal-version:       2.4
+cabal-version:       2.2
 name:                ilist
 version:             0.4.0.1
 synopsis:            Optimised list functions for doing index-related things
@@ -37,11 +37,11 @@ common common-options
                        -Widentities
                        -Wincomplete-uni-patterns
                        -Wincomplete-record-updates
-                       -Wredundant-constraints
                        -fhide-source-paths
   if impl(ghc >= 8.4)
     ghc-options:       -Wmissing-export-lists
                        -Wpartial-fields
+                       -Wredundant-constraints
   if impl(ghc >= 8.8)
     ghc-options:       -Wmissing-deriving-strategies
                        -Werror=missing-deriving-strategies


### PR DESCRIPTION
Fixes issues encountered when building with GHC8.4 under nix packaging.

When building via the "cabal-install" tool, this will usually use a version of the Cabal library that is built with the tool, which is often fairly recent.  The `nix` (https://nixos.org/) build process instead will perform `ghc --make -o Setup Setup.hs; ./Setup configure; ...`, which utilizes the version of the Cabal library that is associated with the corresponding GHC version.

Using nix, the ilist builds under GHC 8.4.4 are failing on the configure step (`Warning: ilist.cabal:0:0: Unsuppoerted cabal-version. ... Setup: Failed parsing "./ilist.cabal"`) because the version of Cabal used is 2.2.0.1.

It appears that there is nothing in the ilist.cabal file that requires cabal version 2.4, so dropping the cabal version requirement for 2.2 allows the package to configure properly.

I also needed to shift the warning because GHC 8.4.4 was indicating that `Semigroup m` was a redundant constraint for `ifoldMap` on line 265 of `src/Data/List/Index.hs`.
